### PR TITLE
adds space before closing parenthesis

### DIFF
--- a/DeployLocally/deploy/proglog/templates/statefulset.yaml
+++ b/DeployLocally/deploy/proglog/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
                 {{.Values.serfPort}}"
             $([ $ID != 0 ] && echo 'start-join-addrs: \
               "proglog-0.proglog.{{.Release.Namespace}}.svc.cluster.local:\
-                {{.Values.serfPort}}"')
+                {{.Values.serfPort}}"' )
             bootstrap: $([ $ID = 0 ] && echo true || echo false )            
             EOD   
         volumeMounts:

--- a/DeployToCloud/deploy/proglog/templates/statefulset.yaml
+++ b/DeployToCloud/deploy/proglog/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
             rpc-port: {{.Values.rpcPort}}
             bind-addr: "$HOSTNAME.proglog.{{.Release.Namespace}}.svc.cluster.local:{{.Values.serfPort}}"
             bootstrap: $([ $ID = 0 ] && echo true || echo false )
-            $([ $ID != 0 ] && echo 'start-join-addrs: "proglog-0.proglog.{{.Release.Namespace}}.svc.cluster.local:{{.Values.serfPort}}"')
+            $([ $ID != 0 ] && echo 'start-join-addrs: "proglog-0.proglog.{{.Release.Namespace}}.svc.cluster.local:{{.Values.serfPort}}"' )
             EOD
         volumeMounts:
         - name: datadir


### PR DESCRIPTION
When deploying to kubernetes locally, the pods are crashlooping. Looking at the logs the error was:
Error: While parsing config: yaml

It seems like the config file we create in initContainers is failing to be parsed by the cobra package. Adding the extra space seems to have fixed it
